### PR TITLE
fix: Update deprecated actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/build_android.yml
+++ b/.github/workflows/build_android.yml
@@ -1,0 +1,40 @@
+name: Build Android APK
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Set up JDK 11
+      uses: actions/setup-java@v3
+      with:
+        distribution: 'temurin'
+        java-version: '11'
+
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: '1.21.1'
+
+    - name: Grant execute permission for gradlew
+      run: chmod +x Android/gradlew
+
+    - name: Build with Gradle
+      run: |
+        cd Android
+        ./gradlew assembleDebug
+
+    - name: Upload APK
+      uses: actions/upload-artifact@v4
+      with:
+        name: app-debug
+        path: Android/app/build/outputs/apk/debug/app-debug.apk


### PR DESCRIPTION
The GitHub Actions workflow was failing because `actions/upload-artifact@v3` is deprecated. This commit updates the workflow to use the recommended `actions/upload-artifact@v4`.

This resolves the build failure reported by the user.